### PR TITLE
Codecs option for custom encoders

### DIFF
--- a/benchmarks/bench.txt
+++ b/benchmarks/bench.txt
@@ -1,20 +1,20 @@
 goos: darwin
 goarch: arm64
 pkg: larking.io/benchmarks
-BenchmarkLarking/GRPC_GetBook-8         	   16369	     72200 ns/op	   25558 B/op	     230 allocs/op
-BenchmarkLarking/HTTP_GetBook-8         	   26710	     45604 ns/op	    9343 B/op	     154 allocs/op
-BenchmarkLarking/HTTP_UpdateBook-8      	   24991	     47955 ns/op	   11417 B/op	     180 allocs/op
-BenchmarkLarking/HTTP_DeleteBook-8      	   32582	     37221 ns/op	    7614 B/op	     100 allocs/op
-BenchmarkGRPCGateway/GRPC_GetBook-8     	   32691	     37266 ns/op	    9496 B/op	     178 allocs/op
-BenchmarkGRPCGateway/HTTP_GetBook-8     	   25791	     46579 ns/op	   10707 B/op	     173 allocs/op
-BenchmarkGRPCGateway/HTTP_UpdateBook-8  	   23222	     51726 ns/op	   16226 B/op	     223 allocs/op
-BenchmarkGRPCGateway/HTTP_DeleteBook-8  	   32318	     36938 ns/op	    8652 B/op	     112 allocs/op
-BenchmarkEnvoyGRPC/GRPC_GetBook-8       	    8996	    132438 ns/op	   10957 B/op	     177 allocs/op
-BenchmarkEnvoyGRPC/HTTP_GetBook-8       	    7820	    146758 ns/op	    9617 B/op	     161 allocs/op
-BenchmarkEnvoyGRPC/HTTP_UpdateBook-8    	    7794	    151442 ns/op	   10295 B/op	     164 allocs/op
-BenchmarkEnvoyGRPC/HTTP_DeleteBook-8    	    9079	    131140 ns/op	    8670 B/op	     124 allocs/op
-BenchmarkGorillaMux/HTTP_GetBook-8      	   26896	     44423 ns/op	    9522 B/op	     142 allocs/op
-BenchmarkGorillaMux/HTTP_UpdateBook-8   	   26961	     44600 ns/op	   11445 B/op	     165 allocs/op
-BenchmarkGorillaMux/HTTP_DeleteBook-8   	   33387	     35835 ns/op	    7778 B/op	      87 allocs/op
+BenchmarkLarking/GRPC_GetBook-8         	   16398	     71580 ns/op	   25546 B/op	     230 allocs/op
+BenchmarkLarking/HTTP_GetBook-8         	   26587	     44870 ns/op	    9327 B/op	     153 allocs/op
+BenchmarkLarking/HTTP_UpdateBook-8      	   25956	     46836 ns/op	   10867 B/op	     177 allocs/op
+BenchmarkLarking/HTTP_DeleteBook-8      	   32655	     36613 ns/op	    7603 B/op	      99 allocs/op
+BenchmarkGRPCGateway/GRPC_GetBook-8     	   33008	     35987 ns/op	    9496 B/op	     178 allocs/op
+BenchmarkGRPCGateway/HTTP_GetBook-8     	   26355	     45853 ns/op	   10709 B/op	     173 allocs/op
+BenchmarkGRPCGateway/HTTP_UpdateBook-8  	   23402	     51138 ns/op	   16131 B/op	     223 allocs/op
+BenchmarkGRPCGateway/HTTP_DeleteBook-8  	   32468	     36789 ns/op	    8653 B/op	     112 allocs/op
+BenchmarkEnvoyGRPC/GRPC_GetBook-8       	    9064	    131515 ns/op	   10957 B/op	     177 allocs/op
+BenchmarkEnvoyGRPC/HTTP_GetBook-8       	    8240	    141654 ns/op	    9617 B/op	     161 allocs/op
+BenchmarkEnvoyGRPC/HTTP_UpdateBook-8    	    9588	    148711 ns/op	   10295 B/op	     164 allocs/op
+BenchmarkEnvoyGRPC/HTTP_DeleteBook-8    	    9006	    131210 ns/op	    8670 B/op	     124 allocs/op
+BenchmarkGorillaMux/HTTP_GetBook-8      	   27258	     43665 ns/op	    9519 B/op	     142 allocs/op
+BenchmarkGorillaMux/HTTP_UpdateBook-8   	   27136	     44140 ns/op	   11438 B/op	     165 allocs/op
+BenchmarkGorillaMux/HTTP_DeleteBook-8   	   33451	     35662 ns/op	    7784 B/op	      87 allocs/op
 PASS
-ok  	larking.io/benchmarks	24.656s
+ok  	larking.io/benchmarks	24.900s

--- a/larking/mux.go
+++ b/larking/mux.go
@@ -182,7 +182,9 @@ func TypesOption(t protoregistry.MessageTypeResolver) MuxOption {
 func FilesOption(f *protoregistry.Files) MuxOption {
 	return func(opts *muxOptions) { opts.files = f }
 }
-func CodecsOption(contentType string, c Codec) MuxOption {
+
+// CodecOption registers a codec for the given content type.
+func CodecOption(contentType string, c Codec) MuxOption {
 	return func(opts *muxOptions) {
 		if opts.codecs == nil {
 			opts.codecs = make(map[string]Codec)

--- a/larking/negotiate.go
+++ b/larking/negotiate.go
@@ -23,18 +23,18 @@ const (
 	isSpace
 )
 
-// AcceptSpec describes an Accept* header.
-type AcceptSpec struct {
+// acceptSpec describes an Accept* header.
+type acceptSpec struct {
 	Value string
 	Q     float64
 }
 
-// ParseAccept parses Accept* headers.
-func ParseAccept(header http.Header, key string) (specs []AcceptSpec) {
+// parseAccept parses Accept* headers.
+func parseAccept(header http.Header, key string) (specs []acceptSpec) {
 loop:
 	for _, s := range header[key] {
 		for {
-			var spec AcceptSpec
+			var spec acceptSpec
 			spec.Value, s = expectTokenSlash(s)
 			if spec.Value == "" {
 				continue loop
@@ -113,14 +113,14 @@ func expectQuality(s string) (q float64, rest string) {
 	return q + float64(n)/float64(d), s[i:]
 }
 
-// NegotiateContentEncoding returns the best offered content encoding for the
+// negotiateContentEncoding returns the best offered content encoding for the
 // request's Accept-Encoding header. If two offers match with equal weight and
 // then the offer earlier in the list is preferred. If no offers are
 // acceptable, then "" is returned.
-func NegotiateContentEncoding(header http.Header, offers []string) string {
+func negotiateContentEncoding(header http.Header, offers []string) string {
 	bestOffer := "identity"
 	bestQ := -1.0
-	specs := ParseAccept(header, "Accept-Encoding")
+	specs := parseAccept(header, "Accept-Encoding")
 	for _, offer := range offers {
 		for _, spec := range specs {
 			if spec.Q > bestQ &&
@@ -136,16 +136,16 @@ func NegotiateContentEncoding(header http.Header, offers []string) string {
 	return bestOffer
 }
 
-// NegotiateContentType returns the best offered content type for the request's
+// negotiateContentType returns the best offered content type for the request's
 // Accept header. If two offers match with equal weight, then the more specific
 // offer is preferred.  For example, text/* trumps */*. If two offers match
 // with equal weight and specificity, then the offer earlier in the list is
 // preferred. If no offers match, then defaultOffer is returned.
-func NegotiateContentType(header http.Header, offers []string, defaultOffer string) string {
+func negotiateContentType(header http.Header, offers []string, defaultOffer string) string {
 	bestOffer := defaultOffer
 	bestQ := -1.0
 	bestWild := 3
-	specs := ParseAccept(header, "Accept")
+	specs := parseAccept(header, "Accept")
 	for _, offer := range offers {
 		for _, spec := range specs {
 			switch {


### PR DESCRIPTION
Allows for custom encoders. Defines a more efficient  API for codecs with `MarshalAppend` to reuse byte slices. 