### PR TITLE
Add twirp error support for twirp clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,10 @@ This will split into two messages.
 Protobuf messages require the length to be encoded before the message `[4 byte length]<binary encoded>`.
 
 #### Twirp
-The Twirp protocol is very similar to the implicit transcoding requests.
+Twirp is supported through gRPC-transcoding with the implicit methods.
 The implicit methods cover `POST /package.Service/Method/` matching the content types for both `application/json` and `application/proto`.
 Before the [v7 spec](https://twitchtv.github.io/twirp/docs/spec_v7.html) the URL required the `/twirp` prefix.
 We can encode the server to use a ServerOption:
-
 ```go
 svr, _ := larking.NewServer(mux,
 		larking.MuxHandleOption("/", "/twirp"), // Serve mux on '/' and '/twirp'

--- a/README.md
+++ b/README.md
@@ -208,3 +208,19 @@ This will split into two messages.
 
 Protobuf messages require the length to be encoded before the message `[4 byte length]<binary encoded>`.
 
+#### Twirp
+The Twirp protocol is very similar to the implicit transcoding requests.
+The implicit methods cover `POST /package.Service/Method/` matching the content types for both `application/json` and `application/proto`.
+Before the [v7 spec](https://twitchtv.github.io/twirp/docs/spec_v7.html) the URL required the `/twirp` prefix.
+We can encode the server to use a ServerOption:
+
+```go
+svr, _ := larking.NewServer(mux,
+		larking.MuxHandleOption("/", "/twirp"), // Serve mux on '/' and '/twirp'
+)
+```
+
+Twirp [errors](https://twitchtv.github.io/twirp/docs/errors.html) are created from `*grpc.Status` errors.
+Code enums are mapped to twirp error strings and messages. Currently meta fields aren't supported.
+Errors will only be converted to twirp errors when the header `Twirp-Version` is set.
+This is used to identify a twirp request.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -8,6 +8,7 @@ Larking serves both JSON and Protobuf encoded requests, tests marked with `+pb` 
 
 ### Optimisations
 - https://www.emcfarlane.com/blog/2023-04-18-profile-lexer
+- https://www.emcfarlane.com/blog/2023-05-01-bufferless-append
 
 ## gRPC-Gateway
 

--- a/benchmarks/twirp_test.go
+++ b/benchmarks/twirp_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/twitchtv/twirp"
+	"golang.org/x/sync/errgroup"
+	"larking.io/benchmarks/api/librarypb"
+	"larking.io/larking"
+)
+
+func TestTwirp(t *testing.T) {
+	ctx := context.Background()
+	svc := &testService{}
+
+	mux, err := larking.NewMux()
+	if err != nil {
+		t.Fatal(err)
+	}
+	librarypb.RegisterLibraryServiceServer(mux, svc)
+
+	ts, err := larking.NewServer(mux,
+		larking.InsecureServerOption(),
+		larking.MuxHandleOption("/", "/twirp"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer lis.Close()
+
+	var g errgroup.Group
+	defer func() {
+		if err := g.Wait(); err != nil {
+			t.Fatal(err)
+		}
+		t.Log("all server shutdown")
+	}()
+	g.Go(func() (err error) {
+		if err := ts.Serve(lis); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	})
+	defer func() {
+		t.Log("shutdown server")
+		if err := ts.Shutdown(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	{ // proto
+		ccproto := librarypb.NewLibraryServiceProtobufClient("http://"+lis.Addr().String(), &http.Client{})
+
+		book, err := ccproto.GetBook(ctx, &librarypb.GetBookRequest{
+			Name: "shelves/1/books/1",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(book, err)
+
+		// 404
+		if _, err = ccproto.GetBook(ctx, &librarypb.GetBookRequest{
+			Name: "shelves/1/books/404",
+		}); err == nil {
+			t.Fatal("should be 404")
+		} else {
+			var twerr twirp.Error
+			if errors.As(err, &twerr) {
+				t.Log(twerr.Code(), twerr.Msg())
+				if twerr.Code() != twirp.NotFound {
+					t.Errorf("should be %s, but got %s", twirp.NotFound, twerr.Code())
+				}
+			} else {
+				t.Error(err)
+			}
+		}
+
+		if _, err := ccproto.CreateBook(ctx, &librarypb.CreateBookRequest{
+			Parent: "shelves/1",
+			Book: &librarypb.Book{
+				Name:  "shelves/1/books/2",
+				Title: "book2",
+			},
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if _, err := ccproto.DeleteBook(ctx, &librarypb.DeleteBookRequest{
+			Name: "shelves/1/books/1",
+		}); err != nil {
+			t.Error(err)
+		}
+	}
+
+	{ // json
+		ccjson := librarypb.NewLibraryServiceJSONClient("http://"+lis.Addr().String(), &http.Client{})
+		book, err := ccjson.GetBook(ctx, &librarypb.GetBookRequest{
+			Name: "shelves/1/books/1",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(book, err)
+
+		// 404
+		if _, err = ccjson.GetBook(ctx, &librarypb.GetBookRequest{
+			Name: "shelves/1/books/404",
+		}); err == nil {
+			t.Fatal("should be 404")
+		} else {
+			var twerr twirp.Error
+			if errors.As(err, &twerr) {
+				t.Log(twerr.Code(), twerr.Msg())
+				if twerr.Code() != twirp.NotFound {
+					t.Errorf("should be %s, but got %s", twirp.NotFound, twerr.Code())
+				}
+			} else {
+				t.Error(err)
+			}
+		}
+
+		if _, err := ccjson.CreateBook(ctx, &librarypb.CreateBookRequest{
+			Parent: "shelves/1",
+			Book: &librarypb.Book{
+				Name:  "shelves/1/books/2",
+				Title: "book2",
+			},
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if _, err := ccjson.DeleteBook(ctx, &librarypb.DeleteBookRequest{
+			Name: "shelves/1/books/1",
+		}); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/larking/http.go
+++ b/larking/http.go
@@ -17,24 +17,25 @@ import (
 )
 
 type streamHTTP struct {
-	opts        muxOptions
-	ctx         context.Context
-	method      *method
-	w           io.Writer
-	wHeader     http.Header
-	rbuf        []byte    // stream read buffer
-	r           io.Reader //
-	rHeader     http.Header
-	header      metadata.MD
-	trailer     metadata.MD
-	params      params
-	accept      string
-	contentType string
-	recvCount   int
-	sendCount   int
-	sentHeader  bool
-	hasBody     bool // HTTP method has a body
-	rEOF        bool // stream read EOF
+	opts           muxOptions
+	ctx            context.Context
+	method         *method
+	w              io.Writer
+	wHeader        http.Header
+	rbuf           []byte    // stream read buffer
+	r              io.Reader //
+	rHeader        http.Header
+	header         metadata.MD
+	trailer        metadata.MD
+	params         params
+	contentType    string
+	accept         string
+	acceptEncoding string
+	recvCount      int
+	sendCount      int
+	sentHeader     bool
+	hasBody        bool // HTTP method has a body
+	rEOF           bool // stream read EOF
 }
 
 func (s *streamHTTP) SetHeader(md metadata.MD) error {
@@ -76,6 +77,7 @@ func (s *streamHTTP) writeMsg(c Codec, b []byte, contentType string) (int, error
 	if count == 0 {
 		s.wHeader.Set("Content-Type", contentType)
 		setOutgoingHeader(s.wHeader, s.header, s.trailer)
+		s.sentHeader = true
 	}
 	s.sendCount += 1
 	if s.method.desc.IsStreamingServer() {

--- a/larking/http.go
+++ b/larking/http.go
@@ -57,7 +57,7 @@ func (s *streamHTTP) SendHeader(md metadata.MD) error {
 	if sh := s.opts.statsHandler; sh != nil {
 		sh.HandleRPC(s.ctx, &stats.OutHeader{
 			Header:      s.header.Copy(),
-			Compression: s.rHeader.Get("Accept-Encoding"),
+			Compression: s.acceptEncoding,
 		})
 	}
 	return nil


### PR DESCRIPTION
Allows twirp clients to call gRPC services. Status errors are mapped to twirp errors.